### PR TITLE
[Dialogs] Expose corner radius property

### DIFF
--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -90,6 +90,9 @@
 /** The color applied to the button ink effect of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *buttonInkColor;
 
+/** The corner radius of Alert Controller. Default radius is CALayer's default radius (0.0).*/
+@property(nonatomic, assign) CGFloat cornerRadius;
+
 // TODO(iangordon): Add support for preferredAction to match UIAlertController.
 // TODO(iangordon): Consider adding support for UITextFields to match UIAlertController.
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -212,6 +212,13 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
 }
 
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  _cornerRadius = cornerRadius;
+  if (self.alertView) {
+    self.alertView.cornerRadius = cornerRadius;
+  }
+}
+
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
   _mdc_adjustsFontForContentSizeCategory = adjusts;
 
@@ -308,6 +315,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   self.alertView.buttonColor = self.buttonTitleColor;
   self.alertView.buttonFont = self.buttonFont;
   self.alertView.buttonInkColor = self.buttonInkColor;
+  self.alertView.cornerRadius = self.cornerRadius;
 
   for (MDCAlertAction *action in self.actions) {
     [self addActionToAlertView:action];

--- a/components/Dialogs/src/MDCAlertControllerView.h
+++ b/components/Dialogs/src/MDCAlertControllerView.h
@@ -28,6 +28,8 @@
 @property(nonatomic, strong, nullable) UIColor *buttonColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *buttonInkColor UI_APPEARANCE_SELECTOR;
 
+@property(nonatomic, assign) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;
+
 /*
  Indicates whether the view's contents should automatically update their font when the device’s
  UIContentSizeCategory changes.

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -258,6 +258,16 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   }
 }
 
+
+- (CGFloat) cornerRadius {
+  return self.layer.cornerRadius;
+}
+
+- (void)setCornerRadius:(CGFloat)cornerRadius {
+  self.layer.cornerRadius = cornerRadius;
+  [self setNeedsLayout];
+}
+
 #pragma mark - Internal
 
 


### PR DESCRIPTION
Exposing a corner radius property on MDCAlertController.

This requires followup work on correctly applying shadows to the dialogs with rounded corners, which will be implemented in a followup PR.

Issue: #4964: [Dialogs] Expose corner radius property
Required for b/113257098.